### PR TITLE
segfault bugfix

### DIFF
--- a/src/oj/val.c
+++ b/src/oj/val.c
@@ -989,6 +989,7 @@ _oj_val_set_str(ojVal val, const char *s, size_t len) {
 	val->str.s4k->str[len] = '\0';
     } else {
 	val->str.ptr = (char*)OJ_MALLOC(len + 1);
+	val->str.cap = len + 1;
 	memcpy(val->str.ptr, s, len);
 	val->str.ptr[len] = '\0';
     }


### PR DESCRIPTION
I've fixed a bug, which caused segfaults. Without fix, strings' cap field was set to wrong value, so when strings are being concatenated, memory hasn't been reallocated. Concatenated string was written to old buffer, destructing heap and causing segfault.